### PR TITLE
Change item strategy on upgrade

### DIFF
--- a/src/TowerDefense.Api/GameLogic/Decorator/DamageDecorator.cs
+++ b/src/TowerDefense.Api/GameLogic/Decorator/DamageDecorator.cs
@@ -1,4 +1,6 @@
-﻿using TowerDefense.Api.GameLogic.Grid;
+﻿using TowerDefense.Api.GameLogic.Builders;
+using TowerDefense.Api.GameLogic.Grid;
+using TowerDefense.Api.GameLogic.Strategies;
 using TowerDefense.Api.Models;
 using TowerDefense.Api.Models.Items;
 
@@ -18,7 +20,9 @@ namespace TowerDefense.Api.GameLogic.Decorator
 
         public override IEnumerable<AttackDeclaration> Attack(IArenaGrid opponentsArenaGrid, int attackingGridItemId)
         {
-            var attackDeclarations = _item.Attack(opponentsArenaGrid, attackingGridItemId).ToList();
+            var dawAttackStrategy = new DawAttackStrategy();
+            var affectedGridItemList = dawAttackStrategy.AttackedGridItems(opponentsArenaGrid, attackingGridItemId);
+            var attackDeclarations = affectedGridItemList.Select(x => new AttackDeclaration() { GridItemId = x, Damage = Stats.Damage, DamageType = DamageType.Fire });
             IncreaseDamage(attackDeclarations);
             return attackDeclarations;
         }

--- a/src/TowerDefense.Api/GameLogic/Strategies/HorizontalLineAttackStrategy.cs
+++ b/src/TowerDefense.Api/GameLogic/Strategies/HorizontalLineAttackStrategy.cs
@@ -1,6 +1,7 @@
 ﻿using TowerDefense.Api.GameLogic.ArenaAdapter;
 using TowerDefense.Api.GameLogic.Grid;
 using TowerDefense.Api.Constants;
+using static TowerDefense.Api.GameLogic.Strategies.StrategyHelper;
 
 namespace TowerDefense.Api.GameLogic.Strategies
 {
@@ -11,7 +12,8 @@ namespace TowerDefense.Api.GameLogic.Strategies
             var attackingItemRow = attackingGridItemId / Game.MaxGridGridItemsInRow;
             IMatrix opponentsMatrix = new ArenaGridAdapter(opponentsArenaGrid);
             var affectedGridItems = opponentsMatrix.GetItemsByRow(attackingItemRow)
-                                                   .OrderByDescending(x => x.Id);
+                                                    .Where(x => IsItemDamageable(x))
+                                                    .OrderByDescending(x => x.Id);
 
             return affectedGridItems.Select(x => x.Id);
         }

--- a/src/TowerDefense.Api/Models/Items/Rockets.cs
+++ b/src/TowerDefense.Api/Models/Items/Rockets.cs
@@ -10,7 +10,7 @@ namespace TowerDefense.Api.Models.Items
         public int Level { get; set; } = 0;
         public ItemType ItemType { get; set; } = ItemType.Rockets;
         public IItemStats Stats { get; set; } = new MediumCostHighDamageItemStats();
-        public IAttackStrategy AttackStrategy { get; set; } = new DawAttackStrategy();
+        public IAttackStrategy AttackStrategy { get; set; } = new FirstInHorizontalLineAttackStrategy();
         public ICollection<string> PowerUps { get; set; } = new List<string>();
 
         public IEnumerable<AttackDeclaration> Attack(IArenaGrid opponentsArenaGrid, int attackingGridItemId)


### PR DESCRIPTION
- When damage decorator is applied strategy is changed to DawAttackStrategy
- Fixed bug when HorizontalAttackStrategy returned GridItems with no items
